### PR TITLE
Fix minor bug when not using containers and add slurm jobs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,8 @@ TILED_API_KEY=<api key>
 
 READ_DIR=/path/to/read/data
 WRITE_DIR=/path/to/write/results
+
+# Slurm jobs
+PARTITIONS='["p1", "p2"]'
+RESERVATIONS='["r1", "r2"]'
+MAX_TIME="1:00:00"

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 test.py
 
 # output dir
+results/
 data/output/
 data/upload/
 data/.file_manager_vars.pkl

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       PREFECT_TAGS: "${PREFECT_TAGS}"
       PREFECT_API_URL: '${PREFECT_API_URL}'
       CONTENT_API_URL: '${CONTENT_API_URL}'
+      TILED_API_KEY: '${TILED_API_KEY}'
       FLOW_NAME: '${FLOW_NAME}'
       TIMEZONE: "${TIMEZONE}"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,9 @@ services:
       TILED_API_KEY: '${TILED_API_KEY}'
       FLOW_NAME: '${FLOW_NAME}'
       TIMEZONE: "${TIMEZONE}"
+      PARTITIONS: "${PARTITIONS}"
+      RESERVATIONS: "${RESERVATIONS}"
+      MAX_TIME: "${MAX_TIME}"
     volumes:
       - $READ_DIR:/app/work/data
       - $WRITE_DIR:/app/work/mlex_store

--- a/src/app_layout.py
+++ b/src/app_layout.py
@@ -26,10 +26,13 @@ CLUSTER_ALGORITHM_DATABASE = {
 }
 
 DATA_OPTION = [
-    {"label": "Synthetic Shapes", "value": "data/example_shapes/Demoshapes.npz"},
+    {
+        "label": "Synthetic Shapes",
+        "value": f"{os.getcwd()}/data/example_shapes/Demoshapes.npz",
+    },
     {
         "label": "Latent representations from encoder-decoder model",
-        "value": "data/example_latentrepresentation/f_vectors.parquet",
+        "value": f"{os.getcwd()}/data/example_latentrepresentation/f_vectors.parquet",
     },
 ]
 READ_DIR = "data"
@@ -239,8 +242,7 @@ image_panel = [
                         ]
                     )
                 ]
-                
-            )
+            ),
         ],
     )
 ]
@@ -373,7 +375,6 @@ cluster_algo_panel = html.Div(
         )
     ]
 )
-
 
 
 # add alert pop up window

--- a/src/app_layout.py
+++ b/src/app_layout.py
@@ -246,134 +246,107 @@ image_panel = [
 ]
 
 # left panel: choose algorithms, submit job, choose scatter plot attributes, and statistics...
-algo_panel = html.Div(
+algo_panel = dbc.AccordionItem(
     [
-        dbc.Card(
-            id="algo-card",
-            style={"width": "100%"},
-            children=[
-                dbc.Collapse(
-                    children=[
-                        dbc.CardHeader("Select Dimension Reduction Algorithms"),
-                        dbc.CardBody(
-                            [
-                                dbc.Label("Algorithm", className="mr-2"),
-                                dcc.Dropdown(
-                                    id="algo-dropdown",
-                                    options=[
-                                        {"label": entry, "value": entry}
-                                        for entry in ALGORITHM_DATABASE
-                                    ],
-                                    style={"min-width": "250px"},
-                                    value="PCA",
-                                ),
-                                html.Div(id="additional-model-params"),
-                                html.Hr(),
-                                html.Div(
-                                    [
-                                        dbc.Label("Name your job", className="mr-2"),
-                                        dcc.Input(
-                                            id="job-name",
-                                            placeholder="test0",
-                                            style={
-                                                "width": "100%",
-                                                "margin-bottom": "1rem",
-                                            },
-                                        ),
-                                    ]
-                                ),
-                                html.Div(
-                                    [
-                                        dbc.Button(
-                                            "Submit",
-                                            color="secondary",
-                                            id="run-algo",
-                                            outline=True,
-                                            size="lg",
-                                            className="m-1",
-                                            style={"width": "50%"},
-                                        ),
-                                    ],
-                                    className="row",
-                                    style={
-                                        "align-items": "center",
-                                        "justify-content": "center",
-                                    },
-                                ),
-                                html.Hr(),
-                                html.Div(
-                                    [
-                                        dbc.Label("Select a job..."),
-                                        dcc.Dropdown(id="job-selector"),
-                                    ]
-                                ),
-                                html.Div(id="invisible-apply-div"),
-                            ]
+        dbc.CardBody(
+            [
+                dbc.Label("Algorithm", className="mr-2"),
+                dcc.Dropdown(
+                    id="algo-dropdown",
+                    options=[
+                        {"label": entry, "value": entry}
+                        for entry in ALGORITHM_DATABASE
+                    ],
+                    style={"min-width": "250px"},
+                    value="PCA",
+                ),
+                html.Div(id="additional-model-params"),
+                html.Hr(),
+                html.Div(
+                    [
+                        dbc.Label("Name your job", className="mr-2"),
+                        dcc.Input(
+                            id="job-name",
+                            placeholder="test0",
+                            style={
+                                "width": "100%",
+                                "margin-bottom": "1rem",
+                            },
+                        ),
+                    ]
+                ),
+                html.Div(
+                    [
+                        dbc.Button(
+                            "Submit",
+                            color="secondary",
+                            id="run-algo",
+                            outline=True,
+                            size="lg",
+                            className="m-1",
+                            style={"width": "50%"},
                         ),
                     ],
-                    id="model-collapse",
-                    is_open=True,
-                    style={"margin-bottom": "0rem"},
-                )
-            ],
-        )
-    ]
+                    className="row",
+                    style={
+                        "align-items": "center",
+                        "justify-content": "center",
+                    },
+                ),
+                html.Hr(),
+                html.Div(
+                    [
+                        dbc.Label("Select a job..."),
+                        dcc.Dropdown(id="job-selector"),
+                    ]
+                ),
+                html.Div(id="invisible-apply-div"),
+            ]
+        ),
+    ],
+    title="Select Dimension Reduction Algorithms",
 )
 
-cluster_algo_panel = html.Div(
+cluster_algo_panel = dbc.AccordionItem(
     [
-        dbc.Card(
-            id="cluster-algo-card",
-            style={"width": "100%"},
-            children=[
-                dbc.Collapse(
-                    children=[
-                        dbc.CardHeader("Select Clustering Algorithms"),
-                        dbc.CardBody(
-                            [
-                                dbc.Label("Algorithm", className="mr-2"),
-                                dcc.Dropdown(
-                                    id="cluster-algo-dropdown",
-                                    options=[
-                                        {"label": entry, "value": entry}
-                                        for entry in CLUSTER_ALGORITHM_DATABASE
-                                    ],
-                                    style={"min-width": "250px"},
-                                    value="DBSCAN",
-                                ),
-                                html.Div(id="additional-cluster-params"),
-                                html.Hr(),
-                                html.Div(
-                                    [
-                                        dbc.Button(
-                                            "Apply",
-                                            color="secondary",
-                                            id="run-cluster-algo",
-                                            outline=True,
-                                            size="lg",
-                                            className="m-1",
-                                            style={"width": "50%"},
-                                        ),
-                                    ],
-                                    className="row",
-                                    style={
-                                        "align-items": "center",
-                                        "justify-content": "center",
-                                    },
-                                ),
-                                html.Div(id="invisible-submit-div"),
-                            ]
+        dbc.CardBody(
+            [
+                dbc.Label("Algorithm", className="mr-2"),
+                dcc.Dropdown(
+                    id="cluster-algo-dropdown",
+                    options=[
+                        {"label": entry, "value": entry}
+                        for entry in CLUSTER_ALGORITHM_DATABASE
+                    ],
+                    style={"min-width": "250px"},
+                    value="DBSCAN",
+                ),
+                html.Div(id="additional-cluster-params"),
+                html.Hr(),
+                html.Div(
+                    [
+                        dbc.Button(
+                            "Apply",
+                            color="secondary",
+                            id="run-cluster-algo",
+                            outline=True,
+                            size="lg",
+                            className="m-1",
+                            style={"width": "50%"},
                         ),
                     ],
-                    id="cluster-model-collapse",
-                    is_open=True,
-                    style={"margin-bottom": "0rem"},
-                )
-            ],
-        )
-    ]
+                    className="row",
+                    style={
+                        "align-items": "center",
+                        "justify-content": "center",
+                    },
+                ),
+                html.Div(id="invisible-submit-div"),
+            ]
+        ),
+    ],
+    title="Select Clustering Algorithms",
 )
-
 
 
 # add alert pop up window
@@ -390,14 +363,17 @@ modal = html.Div(
     ]
 )
 
-
-control_panel = [
-    algo_panel,
-    cluster_algo_panel,
-    # scatter_control_panel,
-    # heatmap_control_panel,
-    modal,
-]
+control_panel = dbc.Accordion(
+        [
+            algo_panel, 
+            cluster_algo_panel
+        ],
+        style={
+            'position': 'sticky',
+            'top': '10%',
+            'width': '100%'
+            }
+    )
 
 
 # metadata
@@ -429,8 +405,12 @@ app.layout = html.Div(
         dbc.Container(
             children=[
                 dbc.Row(
-                    [dbc.Col(control_panel, width=4), dbc.Col(image_panel, width=8)]
+                    [
+                        dbc.Col(control_panel, width=4, style={'display': 'flex', 'margin-top': '1em'}), 
+                        dbc.Col(image_panel, width=8)
+                    ]
                 ),
+                dbc.Row(dbc.Col(modal)),
                 dbc.Row(dbc.Col(meta)),
             ],
             fluid=True,

--- a/src/assets/sample_models.json
+++ b/src/assets/sample_models.json
@@ -1,0 +1,192 @@
+[
+    {
+        "content_id": "uid1",
+        "content_type": "model",
+        "name": "PCA",
+        "public": true,
+        "version": "1.0.0",
+        "type": "unsupervised",
+        "owner": "mlexchange team",
+        "service_type": "frontend",
+        "docker_image_uri": "ghcr.io/runboj/mlex_dimension_reduction_pca:main",
+        "conda_env_name": "mlex_dimension_reduction_pca",
+        "reference": "PCA algorithm",
+        "application": [
+            "dimension reduction"
+        ],
+        "description": "PCA-based dimension reduction",
+        "gui_parameters": [
+            {
+                "type": "dropdown",
+                "name": "ncomp-dropdown-menu",
+                "title": "Number of Components",
+                "value": 2,
+                "options": [
+                    {
+                        "label": "2",
+                        "value": 2
+                    },
+                    {
+                        "label": "3",
+                        "value": 3
+                    }
+                ],
+                "param_key": "n_components",
+                "comp_group": "all"
+            }
+        ],
+        "cmd": [
+            "python pca_run.py"
+        ],
+        "kwargs": {},
+        "compute_resources": {
+            "num_processors": 1,
+            "num_gpus": 0
+        }
+    },
+    {
+        "content_id": "uid2",
+        "content_type": "model",
+        "name": "UMAP",
+        "public": true,
+        "version": "1.0.0",
+        "type": "unsupervised",
+        "owner": "mlexchange team",
+        "service_type": "frontend",
+        "docker_image_uri": "ghcr.io/runboj/mlex_dimension_reduction_umap:main",
+        "conda_env_name": "mlex_dimension_reduction_umap",
+        "reference": "UMAP algorithm",
+        "application": [
+            "dimension reduction"
+        ],
+        "description": "UMAP algotihtm for dimension reduction",
+        "gui_parameters": [
+            {
+                "type": "dropdown",
+                "name": "ncomp-dropdown-menu-2",
+                "title": "Number of Components",
+                "value": 2,
+                "options": [
+                    {
+                        "label": "2",
+                        "value": 2
+                    },
+                    {
+                        "label": "3",
+                        "value": 3
+                    }
+                ],
+                "param_key": "n_components",
+                "comp_group": "all"
+            },
+            {
+                "type": "dropdown",
+                "name": "mindist-dropdown-menu",
+                "title": "Min distance between points",
+                "value": 0.1,
+                "options": [
+                    {
+                        "label": 0.1,
+                        "value": 0.1
+                    },
+                    {
+                        "label": 0.2,
+                        "value": 0.2
+                    },
+                    {
+                        "label": 0.3,
+                        "value": 0.3
+                    },
+                    {
+                        "label": 0.4,
+                        "value": 0.4
+                    },
+                    {
+                        "label": 0.5,
+                        "value": 0.5
+                    },
+                    {
+                        "label": 0.6,
+                        "value": 0.6
+                    },
+                    {
+                        "label": 0.7,
+                        "value": 0.7
+                    },
+                    {
+                        "label": 0.8,
+                        "value": 0.8
+                    },
+                    {
+                        "label": 0.9,
+                        "value": 0.9
+                    },
+                    {
+                        "label": 1.0,
+                        "value": 1.0
+                    }
+                ],
+                "param_key": "min_dist",
+                "comp_group": "all"
+            },
+            {
+                "type": "dropdown",
+                "name": "nneighbor-dropdown-menu",
+                "title": "Number of Nearest Neighbors",
+                "value": 15,
+                "options": [
+                    {
+                        "label": 5,
+                        "value": 5
+                    },
+                    {
+                        "label": 10,
+                        "value": 10
+                    },
+                    {
+                        "label": 15,
+                        "value": 15
+                    },
+                    {
+                        "label": 20,
+                        "value": 20
+                    },
+                    {
+                        "label": 25,
+                        "value": 25
+                    },
+                    {
+                        "label": 30,
+                        "value": 30
+                    },
+                    {
+                        "label": 35,
+                        "value": 35
+                    },
+                    {
+                        "label": 40,
+                        "value": 40
+                    },
+                    {
+                        "label": 45,
+                        "value": 45
+                    },
+                    {
+                        "label": 50,
+                        "value": 50
+                    }
+                ],
+                "param_key": "n_neighbors",
+                "comp_group": "all"
+            }
+        ],
+        "cmd": [
+            "python umap_run.py"
+        ],
+        "kwargs": {},
+        "compute_resources": {
+            "num_processors": 1,
+            "num_gpus": 0
+        }
+    }
+]

--- a/src/assets/segmentation-style.css
+++ b/src/assets/segmentation-style.css
@@ -32,3 +32,8 @@ label {
     margin: 0;
     border-style: solid;
 }
+
+.accordion-button {
+    font-size: large;
+    font-weight: bold;
+}

--- a/src/frontend.py
+++ b/src/frontend.py
@@ -44,11 +44,13 @@ PREFECT_TAGS = json.loads(os.getenv("PREFECT_TAGS", '["latent-space-explorer"]')
 TIMEZONE = os.getenv("TIMEZONE", "US/Pacific")
 FLOW_NAME = os.getenv("FLOW_NAME", "")
 FLOW_TYPE = "conda"
-CONDA_ENV_NAME = "dimension_reduction_pca"
 
 CONTENT_API_URL = os.getenv("CONTENT_API_URL", "http://localhost:8000/api/v0/models")
 DEFAULT_ALGORITHM_DESCRIPTION = os.getenv("DEFAULT_ALGORITHM_DESCRIPTION")
 
+PARTITIONS = os.getenv("PARTITIONS", None)
+RESERVATIONS = os.getenv("RESERVATIONS", None)
+MAX_TIME = os.getenv("MAX_TIME", "1:00:00")
 
 if FLOW_TYPE == "podman":
     TRAIN_PARAMS_EXAMPLE = {
@@ -69,29 +71,12 @@ if FLOW_TYPE == "podman":
         ],
     }
 
-    INFERENCE_PARAMS_EXAMPLE = {
-        "flow_type": "podman",
-        "params_list": [
-            {
-                "image_name": "ghcr.io/runboj/mlex_dimension_reduction_pca",
-                "image_tag": "main",
-                "command": 'python -c \\"import time; time.sleep(30)\\"',
-                "params": {
-                    "io_parameters": {"uid_save": "uid0001", "uid_retrieve": None}
-                },
-                "volumes": [
-                    f"{READ_DIR}:/app/work/data",
-                    f"{WRITE_DIR}:/app/work/mlex_store",
-                ],
-            },
-        ],
-    }
-else:
+elif FLOW_TYPE == "conda":
     TRAIN_PARAMS_EXAMPLE = {
         "flow_type": "conda",
         "params_list": [
             {
-                "conda_env_name": f"{CONDA_ENV_NAME}",
+                "conda_env_name": "mlex_dimension_reduction_pca",
                 "params": {
                     "io_parameters": {"uid_save": "uid0001", "uid_retrieve": None}
                 },
@@ -99,15 +84,21 @@ else:
         ],
     }
 
-    INFERENCE_PARAMS_EXAMPLE = {
-        "flow_type": "conda",
+else:
+    TRAIN_PARAMS_EXAMPLE = {
+        "flow_type": "slurm",
         "params_list": [
             {
-                "conda_env_name": f"{CONDA_ENV_NAME}",
+                "job_name": "latent_space_explorer",
+                "num_nodes": 1,
+                "partitions": PARTITIONS,
+                "reservations": RESERVATIONS,
+                "max_time": MAX_TIME,
+                "conda_env_name": "mlex_dimension_reduction_pca",
                 "params": {
                     "io_parameters": {"uid_save": "uid0001", "uid_retrieve": None}
                 },
-            },
+            }
         ],
     }
 
@@ -130,8 +121,8 @@ def show_dimension_reduction_gui_layouts(selected_algo):
         data = requests.get(CONTENT_API_URL).json()  # all model
     except Exception as e:
         print(f"Cannot access content api: {e}", flush=True)
-        with open(DEFAULT_ALGORITHM_DESCRIPTION, "r") as f:
-            data = [json.load(f)]
+        with open("src/assets/sample_models.json", "r") as f:
+            data = json.load(f)
 
     if selected_algo == "PCA":
         conditions = {"name": "PCA"}
@@ -345,32 +336,41 @@ def submit_dimension_reduction_job(
     if data_clinic_file_path is not None:
         auto_io_params = io_parameters.copy()
         auto_io_params["model_dir"] = data_clinic_file_path + "/last.ckpt"
+        auto_params = (
+            {
+                "io_parameters": auto_io_params,
+                "target_width": 64,
+                "target_height": 64,
+                "batch_size": 32,
+            },
+        )
+        # TODO: Use content registry to retrieve the model parameters
         if FLOW_TYPE == "podman":
             autoencoder_params = {
                 "image_name": "ghcr.io/mlexchange/mlex_pytorch_autoencoders:main",
                 "image_tag": "main",
                 "command": "python src/predict_model.py",
-                "params": {
-                    "io_parameters": auto_io_params,
-                    "target_width": 64,
-                    "target_height": 64,
-                    "batch_size": 32,
-                },
+                "params": auto_params,
                 "volumes": [
                     f"{READ_DIR}:/app/work/data",
                     f"{WRITE_DIR}:/app/work/mlex_store",
                 ],
             }
-        else:
+        elif FLOW_TYPE == "conda":
             autoencoder_params = {
                 "conda_env_name": "pytorch_autoencoders",
-                "params": {
-                    "io_parameters": auto_io_params,
-                    "target_width": 64,
-                    "target_height": 64,
-                    "batch_size": 32,
-                },
+                "params": auto_params,
                 "python_file_name": "mlex_pytorch_autoencoders/src/predict_model.py",
+            }
+        else:
+            autoencoder_params = {
+                "job_name": "latent_space_explorer",
+                "num_nodes": 1,
+                "partitions": PARTITIONS,
+                "reservations": RESERVATIONS,
+                "max_time": MAX_TIME,
+                "conda_env_name": "pytorch_autoencoders",
+                "params": auto_params,
             }
         job_params["params_list"].insert(0, autoencoder_params)
 

--- a/src/frontend.py
+++ b/src/frontend.py
@@ -402,7 +402,7 @@ def submit_dimension_reduction_job(
     job_params["params_list"][-1]["params"]["io_parameters"] = io_parameters
     job_params["params_list"][-1]["params"]["io_parameters"][
         "output_dir"
-    ] = "mlex_store"
+    ] = f"{os.getcwd()}/mlex_store"
     job_params["params_list"][-1]["params"]["io_parameters"]["uid_save"] = ""
     job_params["params_list"][-1]["params"]["io_parameters"]["uid_retrieve"] = None
     job_params["params_list"][-1]["params"]["model_parameters"] = input_params
@@ -701,18 +701,18 @@ def update_heatmap(
                 selected_indices, export="pillow"
             )
         # Example dataset
-        elif selected_example_dataset == "data/example_shapes/Demoshapes.npz":
+        elif "data/example_shapes/Demoshapes.npz" in selected_example_dataset:
             print("Demoshapes.npz")
-            selected_images = np.load("/app/work/" + selected_example_dataset)["arr_0"][
+            selected_images = np.load(selected_example_dataset)["arr_0"][
                 selected_indices
             ]
             print(selected_images.shape)
         elif (
-            selected_example_dataset
-            == "data/example_latentrepresentation/f_vectors.parquet"
+            "data/example_latentrepresentation/f_vectors.parquet"
+            in selected_example_dataset
         ):
-            print("f_vectors.parque")
-            df = pd.read_parquet("/app/work/" + selected_example_dataset)
+            print("f_vectors.parquet")
+            df = pd.read_parquet(selected_example_dataset)
             selected_images = df.iloc[selected_indices].values
         selected_images = np.array(selected_images)
 

--- a/src/frontend.py
+++ b/src/frontend.py
@@ -43,7 +43,7 @@ UPLOAD_FOLDER_ROOT = "data/upload"
 PREFECT_TAGS = json.loads(os.getenv("PREFECT_TAGS", '["latent-space-explorer"]'))
 TIMEZONE = os.getenv("TIMEZONE", "US/Pacific")
 FLOW_NAME = os.getenv("FLOW_NAME", "")
-FLOW_TYPE = "conda"
+FLOW_TYPE = "podman" #"conda"
 CONDA_ENV_NAME = "dimension_reduction_pca"
 
 CONTENT_API_URL = os.getenv("CONTENT_API_URL", "http://localhost:8000/api/v0/models")


### PR DESCRIPTION
This PR adds the following:
- When running outside containers, the example datasets cannot be used to them being bounded to `/app/work/...`. To avoid this, this PR add `os.getcwd()` to get the full datapath to the dataset, such that it can support both containers and local deployment outside containers
- Adds slurm jobs
- Adds json file with sample dimension reduction techniques when mlex_content is not available
